### PR TITLE
Fix for picker showing and hiding again

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -636,7 +636,7 @@ describe("flatpickr", () => {
       fp._input.focus();
 
       expect(fp.isOpen).toBe(true);
-      simulate("click", window.document.body, { which: 1 }, CustomEvent);
+      simulate("mousedown", window.document.body, { which: 1 }, CustomEvent);
       fp._input.blur();
 
       expect(fp.isOpen).toBe(false);
@@ -653,7 +653,7 @@ describe("flatpickr", () => {
       expect(fp.selectedDates.length).toBe(1);
 
       fp.isOpen = true;
-      simulate("click", window.document.body, { which: 1 }, CustomEvent);
+      simulate("mousedown", window.document.body, { which: 1 }, CustomEvent);
       expect(fp.isOpen).toBe(false);
       expect(fp.selectedDates.length).toBe(0);
       expect(fp._input.value).toBe("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,11 +423,11 @@ function FlatpickrInstance(
 
     if (window.ontouchstart !== undefined)
       bind(window.document, "touchstart", documentClick);
-    else bind(window.document, "click", documentClick);
+    else bind(window.document, "mousedown", documentClick);
     bind(window.document, "focus", documentClick, { capture: true });
 
     bind(self._input, "focus", self.open);
-    bind(self._input, "click", self.open);
+    bind(self._input, "mousedown", self.open);
 
     if (self.daysContainer !== undefined) {
       bind(self.monthNav, "click", onMonthNavClick);


### PR DESCRIPTION
In some cases, the mousedown and the mouseup events would not have the same target; this is because the calendar gets drawn under the cursor during the focus event, which steals the mousedown event, ultimately meaning a click is run on the document instead of on self._input. This patch updates both the document handler and the input event handler to use mousedown instead of click, ensuring the calendar doesn't flash on and off the screen. This addresses issue #2286.